### PR TITLE
Allow for manual trigger of image push workflow

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - $default-branch
+  workflow_dispatch:
+    branches:
+      - "*"
 
 jobs:
   push-image:


### PR DESCRIPTION
This means a new image (with updated dependencies, base image, e.t.c) can be build and pushed without having to commit a change to the default branch