### PR TITLE
Disable New Relic in development mode

### DIFF
--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -31,6 +31,7 @@ common: &default_settings
 development:
   <<: *default_settings
   app_name: Postcoder (Development)
+  agent_enabled: false
 
 test:
   <<: *default_settings


### PR DESCRIPTION
New Relic should not be enabled in development mode. This allows for easier local and CI testing of the image and chart.