### PR TITLE
🔧 Enable releases via tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,8 @@ on:
   push:
     branches:
       - main
-      - "[0-9]*"
+    tags:
+      - "v*"
 
 jobs:
   publish:
@@ -21,7 +22,7 @@ jobs:
         with:
           aws_access_key: ${{ secrets.PUBLIC_PUSH_ECR_AWS_KEY }}
           aws_secret_key: ${{ secrets.PUBLIC_PUSH_ECR_AWS_SECRET }}
-          dockerfile_context: '.'
+          dockerfile_context: "."
           repository_name: postcoder
-          multiarch_build: 'enabled'
+          multiarch_build: "enabled"
           auth_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Changes
Moves us to managing releases via tags rather than by branches. This is a common pattern we have implemented on other repositories (e.g. all of our mock APIs now use this).